### PR TITLE
upgraded pdfbox to 2.0.11 due to potential security issue

### DIFF
--- a/norconex-importer/pom.xml
+++ b/norconex-importer/pom.xml
@@ -27,7 +27,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <site.baseurl/>
     <tika.version>1.16</tika.version>
-    <pdfbox.version>2.0.7</pdfbox.version>
+    <pdfbox.version>2.0.11</pdfbox.version>
     <norconex-commons-lang.version>1.15.0</norconex-commons-lang.version>
   </properties>
   <inceptionYear>2009</inceptionYear>


### PR DESCRIPTION
In Apache PDFBox 1.8.0 to 1.8.14 and 2.0.0RC1 to 2.0.10, a carefully crafted (or fuzzed) file can trigger an infinite loop which leads to an out of memory exception in Apache PDFBox's AFMParser.

See:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8036