### PR TITLE
Fix documentation error in SplitTagger

### DIFF
--- a/src/main/java/com/norconex/importer/handler/tagger/impl/SplitTagger.java
+++ b/src/main/java/com/norconex/importer/handler/tagger/impl/SplitTagger.java
@@ -80,8 +80,8 @@ import com.norconex.importer.parser.ParseState;
  *
  * {@nx.xml.example
  * <handler class="com.norconex.importer.handler.tagger.impl.SplitTagger">
- *   <fieldMatcher>myField</fieldMatcher>
  *   <split>
+ *     <fieldMatcher>myField</fieldMatcher>
  *     <separator regex="true">\s*,\s*</separator>
  *   </split>
  * </handler>


### PR DESCRIPTION
- [FIX] Fix a documentation in `@nx.xml.example` section which places `<fieldMatcher>` outside the `<split>` tag instead of inside.    

    A misalignment was found in the documentation provided for the SplitTagger class, the full *XML configuration usage* (i.e., `@nx.xml.usage`) section vs. the one for *XML usage example* (i.e., `@nx.xml.example`). It has to do with where to place `<fieldMatcher>` tag. In the former, it indicates that it has to be included and be within the `<split>` tag; while the former places it outside that tag. The suggested changes is for the `@nx.xml.example` to look like the following:    
    ```
    <handler
        class="com.norconex.importer.handler.tagger.impl.SplitTagger">
      <split>
        <fieldMatcher>myField</fieldMatcher>
        <separator
            regex="true">\s*,\s*</separator>
      </split>
    </handler>
    ```